### PR TITLE
Using the correct headers of BlueGreen

### DIFF
--- a/lib/store_request_id/blue_green_middleware.rb
+++ b/lib/store_request_id/blue_green_middleware.rb
@@ -27,7 +27,8 @@ module StoreRequestId
       private
 
       def bg
-        @bg ||= VALUES.fetch(self[HEADER], 'blue')
+        req = ::ActionDispatch::Request.new(self)
+        @bg ||= VALUES.fetch(req.headers[HEADER], 'blue')
       end
 
       def processed

--- a/spec/store_request_id/blue_green_middleware_spec.rb
+++ b/spec/store_request_id/blue_green_middleware_spec.rb
@@ -42,7 +42,7 @@ describe StoreRequestId::BlueGreenMiddleware do
   values.each do |input, expected|
     context "#{expected} when header says #{input}" do
       let(:env) do
-        { 'X-GS-BGEnv' => input }
+        { 'HTTP_X_GS_BGENV' => input }
       end
       it 'persist BG header in :bg' do
         expect(response.status).to eq(200)


### PR DESCRIPTION
When using Rails, the correct headers are `HTTP_X_GS_BGENV`. Now using `ActionDispatch::Request` to have the `headers` helpers.