### PR TITLE
[GSCC-8576] - Update CHANGELOG and README, fix spec and bump version to 0.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,14 @@ sudo: false
 language: ruby
 
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.6.5
+  - 2.7.2
 
 addons:
   code_climate:
     repo_token: 682975bb1f8c2c0c4b854034c70744758c50c832e28c563d8a7e7bdabf821e34
 
-before_install: gem install bundler -v 1.15.3
+before_install: gem install bundler -v 2.1.4
 
 cache:
   - bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.4.1](https://github.com/SparkHub/gs-store-request-id/tree/v0.4.1) (2021-05-13)
+[Full Changelog](https://github.com/SparkHub/gs-store-request-id/compare/v0.4.0...v0.4.1)
+
+- Fix security vulnerability (bundler and rake)
+- Update gem information (author, email)
+- Fix spec constant `ActionDispatch::RequestId::X_REQUEST_ID` not defined
+
 ## [0.4.0](https://github.com/SparkHub/gs-store-request-id/tree/v0.4.0) (2019-07-10)
 [Full Changelog](https://github.com/SparkHub/gs-store-request-id/compare/v0.3.1...v0.4.0)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Middleware storing the unique [requestId](https://github.com/rails/rails/blob/ma
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'store_request_id', '~> 0.3.1'
+gem 'store_request_id', '~> 0.4.1'
 ```
 
 And then execute:

--- a/lib/store_request_id/version.rb
+++ b/lib/store_request_id/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StoreRequestId
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/spec/store_request_id/defaults/storage_spec.rb
+++ b/spec/store_request_id/defaults/storage_spec.rb
@@ -10,7 +10,6 @@ describe StoreRequestId::Defaults::Storage do
 
       context 'with undefined :X_REQUEST_ID' do
         before(:each) do
-          ActionDispatch::RequestId.send(:remove_const, 'X_REQUEST_ID') if RUBY_VERSION >= '2.2.2'
           described_class.send(:remove_const, 'DEFAULT_KEY')
           described_class::DEFAULT_KEY = 'My-Key'
         end

--- a/store_request_id.gemspec
+++ b/store_request_id.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', RUBY_VERSION >= '2.2.2' ? '>= 3.0.2' : '< 5.1.3'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0.1'
+  spec.add_development_dependency 'rake', '~> 13.0.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
- Update CHANGELOG (describe latest changes) and README (latest version)
- Bump version to 0.4.1 
  - Note: This is going to match Nexus and Github versions
- Fix spec `constant ActionDispatch::RequestId::X_REQUEST_ID not defined`

![Screen Shot 2021-05-12 at 4 41 52 PM](https://user-images.githubusercontent.com/13322240/118057493-f71bb880-b340-11eb-8a8f-3e7afb1b316f.png)
